### PR TITLE
Fix: History Deserialization

### DIFF
--- a/metadata/JikanPHP.Model.Common.HistoryMeta.yml
+++ b/metadata/JikanPHP.Model.Common.HistoryMeta.yml
@@ -1,0 +1,10 @@
+JikanPHP\Model\Common\HistoryMeta:
+    properties:
+        malId:
+            type: int
+        type:
+            type: string
+        name:
+            type: string    
+        url:
+            type: string

--- a/metadata/JikanPHP.Model.User.History.yml
+++ b/metadata/JikanPHP.Model.User.History.yml
@@ -1,7 +1,7 @@
 JikanPHP\Model\User\History:
     properties:
-        malUrl:
-            type: JikanPHP\Model\Common\MalUrl
+        meta:
+            type: JikanPHP\Model\Common\HistoryMeta
         increment:
             type: int
         date:

--- a/model/Common/HistoryMeta.php
+++ b/model/Common/HistoryMeta.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace JikanPHP\Model\Common;
+
+/**
+ * Class HistoryMeta
+ *
+ * @package JikanPHP\Model
+ */
+class HistoryMeta
+{
+
+    /**
+     * @var string
+     */
+    private $url;
+
+    /**
+     * @var int
+     */
+    private $malId;
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @return string
+     */
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMalId(): int
+    {
+        return $this->malId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/model/User/History.php
+++ b/model/User/History.php
@@ -2,7 +2,7 @@
 
 namespace JikanPHP\Model\User;
 
-use JikanPHP\Model\Common\MalUrl;
+use JikanPHP\Model\Common\HistoryMeta;
 
 /**
  * Class History
@@ -11,11 +11,10 @@ use JikanPHP\Model\Common\MalUrl;
  */
 class History
 {
-
     /**
-     * @var MalUrl
+     * @var HistoryMeta
      */
-    private $malUrl;
+    private HistoryMeta $meta;
 
     /**
      * @var int
@@ -26,14 +25,6 @@ class History
      * @var \DateTimeImmutable
      */
     private $date;
-
-    /**
-     * @return MalUrl
-     */
-    public function getMalUrl(): MalUrl
-    {
-        return $this->malUrl;
-    }
 
     /**
      * @return int
@@ -49,5 +40,13 @@ class History
     public function getDate(): \DateTimeImmutable
     {
         return $this->date;
+    }
+
+    /**
+     * @return HistoryMeta
+     */
+    public function getMeta(): HistoryMeta
+    {
+        return $this->meta;
     }
 }

--- a/request/User/UserHistoryRequest.php
+++ b/request/User/UserHistoryRequest.php
@@ -36,7 +36,7 @@ class UserHistoryRequest implements RequestInterface
         $this->username = $username;
 
         if (null !== $type) {
-            if (!\in_array($type, ['anime', 'manga'])) {
+            if (!empty($type) && !\in_array($type, ['anime', 'manga'])) {
                 throw new \InvalidArgumentException(sprintf('Type %s is not valid', $type));
             }
 


### PR DESCRIPTION
Fixes the following issues with the user history:

* Allows for an empty `type` parameter within the request which previously would throw an exception.
* Properly deserializes the history response since it seems Jikan shelved all meta properties into the `meta` property.