### PR TITLE
Fix method signature in JaneObjectNormalizer

### DIFF
--- a/src/Normalizer/JaneObjectNormalizer.php
+++ b/src/Normalizer/JaneObjectNormalizer.php
@@ -281,7 +281,7 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
     /**
      * @param null|mixed $format
      */
-    public function denormalize($data, $class, $format = null, array $context = [])
+    public function denormalize($data, string $type, ?string $format = null, array $context = []): mixed
     {
         $denormalizerClass = $this->normalizers[$class];
         $denormalizer = $this->getNormalizer($denormalizerClass);


### PR DESCRIPTION
![imagen](https://github.com/janvernieuwe/jikan-jikanPHP/assets/1966205/8b667af3-d28a-473f-9156-4010b9fcc725)

Adjusted the method signature of the denormalize method in the JaneObjectNormalizer class to match the Symfony\Component\Serializer\Normalizer\DenormalizerInterface. The method signature now conforms to: 

`public function denormalize($data, string $type, ?string $format = null, array $context = []): mixed`

This resolves the compatibility issue and ensures adherence to the interface contract.